### PR TITLE
Add `bundle-stdin` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ async function mochify(options = {}) {
   const driver_promise = mochifyDriver(driver_options);
   const bundler_promise = config.esm
     ? Promise.resolve('')
-    : resolveBundle(config.bundle, resolved_spec);
+    : resolveBundle(config.bundle, resolved_spec, config);
 
   let driver, bundle;
   try {

--- a/lib/load-config.js
+++ b/lib/load-config.js
@@ -22,6 +22,7 @@ const { lilconfig } = require('lilconfig');
  * @property {string} [serve]
  * @property {Object} [server_options]
  * @property {string} [bundle]
+ * @property {'require' | 'import'} [bundle_stdin]
  */
 /**
  * @typedef {Object} MochifyOptionsProps

--- a/lib/resolve-bundle.js
+++ b/lib/resolve-bundle.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const fs = require('fs').promises;
+const { PassThrough } = require('stream');
 const execa = require('execa');
 const { parseArgsStringToArgv } = require('string-argv');
 
 /**
  * @typedef {import('stream').Stream} Stream
  * @typedef {import('execa').ExecaError} ExecaError
+ * @typedef {import('./load-config').MochifyOptions} MochifyOptions
  */
 
 exports.resolveBundle = resolveBundle;
@@ -14,9 +16,10 @@ exports.resolveBundle = resolveBundle;
 /**
  * @param {string | undefined} command
  * @param {string[] | Stream} resolved_spec
+ * @param {MochifyOptions} options
  * @returns {Promise<string>}
  */
-async function resolveBundle(command, resolved_spec) {
+async function resolveBundle(command, resolved_spec, options) {
   if (typeof resolved_spec === 'object' && !Array.isArray(resolved_spec)) {
     return bufferStream(resolved_spec);
   }
@@ -27,9 +30,33 @@ async function resolveBundle(command, resolved_spec) {
 
   const [cmd, ...args] = parseArgsStringToArgv(command);
 
-  const result = await execa(cmd, args.concat(resolved_spec), {
-    preferLocal: true
-  });
+  let result;
+  if (options.bundle_stdin) {
+    const stdin = new PassThrough();
+    switch (options.bundle_stdin) {
+      case 'require':
+        for (const file of resolved_spec) {
+          stdin.write(`require('./${file}');\n`);
+        }
+        break;
+      case 'import':
+        for (const file of resolved_spec) {
+          stdin.write(`import './${file}';\n`);
+        }
+        break;
+      default:
+        throw new Error(`Unknown bundle_stdin option: ${options.bundle_stdin}`);
+    }
+    stdin.end();
+    result = await execa(cmd, args, {
+      preferLocal: true,
+      input: stdin
+    });
+  } else {
+    result = await execa(cmd, args.concat(resolved_spec), {
+      preferLocal: true
+    });
+  }
 
   if (result.failed || result.killed) {
     throw new Error(/** @type {ExecaError} */ (result).shortMessage);

--- a/lib/resolve-bundle.js
+++ b/lib/resolve-bundle.js
@@ -5,16 +5,19 @@ const execa = require('execa');
 const { parseArgsStringToArgv } = require('string-argv');
 
 /**
+ * @typedef {import('stream').Stream} Stream
  * @typedef {import('execa').ExecaError} ExecaError
  */
 
 exports.resolveBundle = resolveBundle;
 
+/**
+ * @param {string | undefined} command
+ * @param {string[] | Stream} resolved_spec
+ * @returns {Promise<string>}
+ */
 async function resolveBundle(command, resolved_spec) {
-  if (
-    typeof resolved_spec === 'object' &&
-    typeof resolved_spec.pipe === 'function'
-  ) {
+  if (typeof resolved_spec === 'object' && !Array.isArray(resolved_spec)) {
     return bufferStream(resolved_spec);
   }
 
@@ -35,11 +38,19 @@ async function resolveBundle(command, resolved_spec) {
   return result.stdout;
 }
 
+/**
+ * @param {string[]} files
+ * @returns {Promise<string>}
+ */
 async function concatFiles(files) {
   const buffers = await Promise.all(files.map((file) => fs.readFile(file)));
   return Buffer.concat(buffers).toString('utf8');
 }
 
+/**
+ * @param {Stream} stream
+ * @returns {Promise<string>}
+ */
 function bufferStream(stream) {
   return new Promise((resolve, reject) => {
     const buffers = [];

--- a/lib/resolve-spec.js
+++ b/lib/resolve-spec.js
@@ -19,5 +19,5 @@ async function resolveSpec(spec = 'test/**/*.js') {
 
   const patterns = Array.isArray(spec) ? spec : [spec];
   const matches = await Promise.all(patterns.map((pattern) => glob(pattern)));
-  return matches.reduce((all, match) => all.concat(match), []);
+  return matches.reduce((all, match) => all.concat(match), []).sort();
 }

--- a/lib/resolve-spec.js
+++ b/lib/resolve-spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const { promisify } = require('util');
-const glob = promisify(require('glob'));
+const { glob } = require('glob');
 
 /**
  * @typedef {import('stream').Stream} Stream
@@ -11,14 +10,10 @@ exports.resolveSpec = resolveSpec;
 
 /**
  * @param {string | string[] | Stream} [spec]
- * @returns {Promise<string | Stream>}
+ * @returns {Promise<string | string[] | Stream>}
  */
 async function resolveSpec(spec = 'test/**/*.js') {
-  if (
-    typeof spec === 'object' &&
-    !Array.isArray(spec) &&
-    typeof spec.pipe === 'function'
-  ) {
+  if (typeof spec === 'object' && !Array.isArray(spec)) {
     return spec;
   }
 

--- a/lib/resolve-spec.js
+++ b/lib/resolve-spec.js
@@ -10,7 +10,7 @@ exports.resolveSpec = resolveSpec;
 
 /**
  * @param {string | string[] | Stream} [spec]
- * @returns {Promise<string | string[] | Stream>}
+ * @returns {Promise<string[] | Stream>}
  */
 async function resolveSpec(spec = 'test/**/*.js') {
   if (typeof spec === 'object' && !Array.isArray(spec)) {

--- a/lib/resolve-spec.test.js
+++ b/lib/resolve-spec.test.js
@@ -2,40 +2,38 @@
 
 const fs = require('fs');
 const proxyquire = require('proxyquire');
-const { assert, sinon } = require('@sinonjs/referee-sinon');
+const { assert, refute, sinon } = require('@sinonjs/referee-sinon');
 
 describe('lib/resolve-spec', () => {
-  let resolveSpec;
-  let glob;
-
-  beforeEach(() => {
-    glob = sinon.fake();
-    ({ resolveSpec } = proxyquire('./resolve-spec', { glob }));
-  });
+  function resolveSpec(glob, pattern) {
+    const sut = proxyquire('./resolve-spec', { glob: { glob } });
+    return sut.resolveSpec(pattern);
+  }
 
   it('resolves glob "test/**/*.js" for undefined', async () => {
-    const promise = resolveSpec(undefined);
     const matches = ['test/this.js', 'test/that.js'];
+    const glob = sinon.fake.resolves(matches);
 
-    assert.calledOnceWith(glob, 'test/**/*.js');
-
-    glob.callback(null, matches);
+    const promise = resolveSpec(glob, undefined);
 
     await assert.resolves(promise, matches);
+    assert.calledOnceWith(glob, 'test/**/*.js');
   });
 
   it('invokes glob with given string pattern', () => {
+    const glob = sinon.fake.returns(sinon.promise());
     const pattern = 'some/*.js';
 
-    resolveSpec(pattern);
+    resolveSpec(glob, pattern);
 
     assert.calledOnceWith(glob, pattern);
   });
 
   it('invokes glob concurrently with patterns from array', () => {
+    const glob = sinon.fake.returns(sinon.promise());
     const patterns = ['a/*.js', 'b/*.js', 'c/*.js'];
 
-    resolveSpec(patterns);
+    resolveSpec(glob, patterns);
 
     assert.calledThrice(glob);
     assert.calledWith(glob, patterns[0]);
@@ -46,9 +44,9 @@ describe('lib/resolve-spec', () => {
   it('resolves with the result from a single pattern', async () => {
     const pattern = 'test/**/*.js';
     const matches = ['test/this.js', 'test/that.js'];
+    const glob = sinon.fake.resolves(matches);
 
-    const promise = resolveSpec(pattern);
-    glob.firstCall.callback(null, matches);
+    const promise = resolveSpec(glob, pattern);
 
     await assert.resolves(promise, matches);
   });
@@ -57,10 +55,19 @@ describe('lib/resolve-spec', () => {
     const patterns = ['a/*.js', 'b/*.js'];
     const matches_a = ['a/this.js', 'a/that.js'];
     const matches_b = ['b/more.js'];
+    let calls = 0;
+    const glob = sinon.fake(() => {
+      switch (++calls) {
+        case 1:
+          return Promise.resolve(matches_a);
+        case 2:
+          return Promise.resolve(matches_b);
+        default:
+          throw new Error(`Unexpected call ${calls}`);
+      }
+    });
 
-    const promise = resolveSpec(patterns);
-    glob.firstCall.callback(null, matches_a);
-    glob.secondCall.callback(null, matches_b);
+    const promise = resolveSpec(glob, patterns);
 
     await assert.resolves(promise, matches_a.concat(matches_b));
   });
@@ -69,17 +76,30 @@ describe('lib/resolve-spec', () => {
     const patterns = ['a/*.js', 'b/*.js'];
     const matches_a = ['a/this.js', 'a/that.js'];
     const error = new Error('Oh noes!');
+    let calls = 0;
+    const glob = sinon.fake(() => {
+      switch (++calls) {
+        case 1:
+          return Promise.resolve(matches_a);
+        case 2:
+          return Promise.reject(error);
+        default:
+          throw new Error(`Unexpected call ${calls}`);
+      }
+    });
 
-    const promise = resolveSpec(patterns);
-    glob.firstCall.callback(null, matches_a);
-    glob.secondCall.callback(error);
+    const promise = resolveSpec(glob, patterns);
 
     await assert.rejects(promise, error);
   });
 
   it('passes through streams', async () => {
     const stream = fs.createReadStream(__filename);
-    const promise = resolveSpec(stream);
+    const glob = sinon.fake();
+
+    const promise = resolveSpec(glob, stream);
+
     await assert.resolves(promise, stream);
+    refute.called(glob);
   });
 });

--- a/lib/resolve-spec.test.js
+++ b/lib/resolve-spec.test.js
@@ -16,7 +16,7 @@ describe('lib/resolve-spec', () => {
 
     const promise = resolveSpec(glob, undefined);
 
-    await assert.resolves(promise, matches);
+    await assert.resolves(promise, matches.slice().sort());
     assert.calledOnceWith(glob, 'test/**/*.js');
   });
 
@@ -48,7 +48,7 @@ describe('lib/resolve-spec', () => {
 
     const promise = resolveSpec(glob, pattern);
 
-    await assert.resolves(promise, matches);
+    await assert.resolves(promise, matches.slice().sort());
   });
 
   it('resolves with the result from a pattern array', async () => {
@@ -69,7 +69,7 @@ describe('lib/resolve-spec', () => {
 
     const promise = resolveSpec(glob, patterns);
 
-    await assert.resolves(promise, matches_a.concat(matches_b));
+    await assert.resolves(promise, matches_a.concat(matches_b).sort());
   });
 
   it('rejects with error from glob', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "convert-source-map": "^1.1.3",
         "deepmerge": "^4.2.2",
         "execa": "^5.1.1",
-        "glob": "^7.1.7",
+        "glob": "^10.3.10",
         "lilconfig": "^3.0.0",
         "mime": "^2.5.2",
         "mocha": "^10.2.0",
@@ -169,7 +169,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "dependencies": {
         "string-width": "^5.1.2",
         "string-width-cjs": "npm:string-width@^4.2.0",
@@ -186,7 +185,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
       "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -198,7 +196,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -209,14 +206,12 @@
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
         "emoji-regex": "^9.2.2",
@@ -233,7 +228,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -248,7 +242,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
         "string-width": "^5.0.1",
@@ -313,7 +306,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">=14"
@@ -1130,8 +1122,7 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
     },
     "node_modules/emoji-regex": {
       "version": "10.3.0",
@@ -1631,6 +1622,26 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flat-cache/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/flat-cache/node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -1665,7 +1676,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
       "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
-      "dev": true,
       "dependencies": {
         "cross-spawn": "^7.0.0",
         "signal-exit": "^4.0.1"
@@ -1681,7 +1691,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "engines": {
         "node": ">=14"
       },
@@ -1790,19 +1799,21 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
       "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1818,6 +1829,28 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -2277,7 +2310,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
       "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -2813,7 +2845,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
       "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
-      "dev": true,
       "engines": {
         "node": "14 || >=16.14"
       }
@@ -2937,6 +2968,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -2957,7 +2989,6 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
       "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
-      "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -3291,7 +3322,6 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
       "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^9.1.1 || ^10.0.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
@@ -3542,52 +3572,6 @@
       },
       "engines": {
         "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "dev": true,
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -3863,7 +3847,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -3876,14 +3859,12 @@
     "node_modules/string-width-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3931,7 +3912,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4259,7 +4239,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -4275,14 +4254,12 @@
     "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/wrap-ansi-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4291,7 +4268,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "convert-source-map": "^1.1.3",
     "deepmerge": "^4.2.2",
     "execa": "^5.1.1",
-    "glob": "^7.1.7",
+    "glob": "^10.3.10",
     "lilconfig": "^3.0.0",
     "mime": "^2.5.2",
     "mocha": "^10.2.0",


### PR DESCRIPTION
When passing multiple files to `esbuild`, it requires an output directory and generates an output file for each input. While this makes sense when bundling apps, it's not what we want when resolving a glob expression to multiple test files.

Unfortunately there is no way to influence this behaviour in `esbuild`.

---

This change introduces the new option `bundle_stdin` which can be set to "require" or "import". When provided, mochify generates a synthetic JavaScript file with `require` / `import` statements for each of the resolved spec files. The result is passed to the `bundle` command via `stdin`.

This allows us to use `esbuild` as a bundler when multiple spec files are present.