### PR TITLE
Remove test framework internal frames from stack traces

### DIFF
--- a/lib/stack-mapper.js
+++ b/lib/stack-mapper.js
@@ -15,11 +15,22 @@ exports.stackMapper = stackMapper;
  */
 async function stackMapper(map) {
   const consumer = await new SourceMapConsumer(map);
-  return (stack) =>
-    parse(stack)
+  return (stack) => {
+    let frames = parse(stack);
+    // Remove test framework internal frames if they don't map to a file:
+    if (frames[0].file) {
+      for (let i = 1; i <= frames.length; i++) {
+        if (!frames[i].file) {
+          frames = frames.slice(0, i);
+          break;
+        }
+      }
+    }
+    return frames
       .map((frame) => mapLine(consumer, frame))
       .filter(Boolean)
       .join('\n');
+  };
 }
 
 /**
@@ -30,7 +41,7 @@ async function stackMapper(map) {
 function mapLine(consumer, frame) {
   const { lineNumber, column, methodName, file } = frame;
 
-  if (lineNumber !== null) {
+  if (lineNumber !== null && file) {
     const mapped = consumer.originalPositionFor({
       line: lineNumber,
       column: column || 0


### PR DESCRIPTION
The test framework internal frames have column numbers and the source map consumer happily mapes these lines to random files.

With this change, all stack frames from the first frame without a `file` onwards are removed from the stack trace. The result is that the line with the origin of the error is usually the last line printed.