### PR TITLE
Fix circular dependencies issue

### DIFF
--- a/client.js
+++ b/client.js
@@ -143,13 +143,13 @@ mocha.mochify_run = function () {
   s.textContent = chunks.join('');
   document.body.appendChild(s);
   // Run mocha
-  mocha.run(function (code) {
+  mocha.run(function (failures) {
     // @ts-ignore
     if (typeof __coverage__ !== 'undefined') {
       // @ts-ignore
       write('mochify.coverage', window.__coverage__);
     }
-    write('mochify.callback', { code: code });
+    write('mochify.callback', { code: failures ? 1 : 0 });
   });
 };
 

--- a/client.js
+++ b/client.js
@@ -170,3 +170,9 @@ window.onerror = function (msg, file, line, column, err) {
     ]);
   }
 };
+
+window.onunhandledrejection = function (event) {
+  write('console.error', [
+    'Unhandled rejection: ' + event.reason.stack || String(event.reason)
+  ]);
+};

--- a/client.js
+++ b/client.js
@@ -163,8 +163,10 @@ mocha.mochify_run = function () {
 
 window.onerror = function (msg, file, line, column, err) {
   if (err) {
-    console.error(err.stack);
+    write('console.error', [err.stack || String(err)]);
   } else {
-    console.error(msg + '\n    at ' + file + ':' + line + ':' + column);
+    write('console.error', [
+      msg + '\n    at ' + file + ':' + line + ':' + column
+    ]);
   }
 };


### PR DESCRIPTION
When trying to send objects with circular dependencies over the wire, puppeteer silently drops the whole thing.