### PR TITLE
build: clean before build when running prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "npm test -- --watch",
     "build": "tsc --project tsconfig.pack.json",
     "clean": "rimraf --glob '!(node_modules)/**/*.d.ts' '*.d.ts' coverage",
-    "prepack": "npm run build",
+    "prepack": "npm run clean && npm run build",
     "postpack": "npm run clean",
     "preversion": "npm run lint && npm run prettier:check && tsc && npm run coverage:check",
     "version": "changes --commits --footer",


### PR DESCRIPTION
The prepack script may fail result in a partial `npm version` run if an existing build was done before start of the script. By running the clean script we end up with consistant runs.